### PR TITLE
Fix and improve text formatting.

### DIFF
--- a/cif_twin.dic
+++ b/cif_twin.dic
@@ -14,7 +14,7 @@ data_CIF_TWIN
     _dictionary.title             CIF_TWIN
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2024-11-28
+    _dictionary.date              2024-11-29
     _dictionary.uri
         https://github.com/COMCIFS/Twinning_Dictionary/blob/main/cif_twin.dic
     _dictionary.ddl_conformance   4.2.0
@@ -376,7 +376,7 @@ save_twin_individual.twin_matrix
 
     _definition.id                '_twin_individual.twin_matrix'
     _alias.definition_id          '_twin_individual_twin_matrix'
-    _definition.update            2014-06-20
+    _definition.update            2024-11-29
     _description.text
 ;
 
@@ -384,9 +384,12 @@ save_twin_individual.twin_matrix
      of the reference twin to give the Miller indices h',k',l',
      of the twin specified by _twin_individual_id
 
-                         (h' k' l') = U (h k l )
+                         | U11  U12  U13 | |h |
+            (h' k' l') = | U21  U22  U23 | |k |
+                         | U31  U32  U33 | |l |
 
-     The reference twin must have U = I, the identity matrix.
+
+     The reference twin must be assigned the identity matrix.
 ;
     _name.category_id             twin_individual
     _name.object_id               twin_matrix
@@ -517,7 +520,7 @@ save_twin_individual.twin_matrix_23
     _description.text
 ;
 
-     The [3,2] element of the matrix U in _twin_individual.twin_matrix.
+     The [2,3] element of the matrix U in _twin_individual.twin_matrix.
 ;
     _name.category_id             twin_individual
     _name.object_id               twin_matrix_23
@@ -537,7 +540,7 @@ save_twin_individual.twin_matrix_31
     _description.text
 ;
 
-     The [1,3] element of the matrix U in _twin_individual.twin_matrix.
+     The [3,1] element of the matrix U in _twin_individual.twin_matrix.
 ;
     _name.category_id             twin_individual
     _name.object_id               twin_matrix_31
@@ -557,7 +560,7 @@ save_twin_individual.twin_matrix_32
     _description.text
 ;
 
-     The [2,3] element of the matrix U in _twin_individual.twin_matrix.
+     The [3,2] element of the matrix U in _twin_individual.twin_matrix.
 ;
     _name.category_id             twin_individual
     _name.object_id               twin_matrix_32
@@ -1168,10 +1171,11 @@ save_
                    Added r to enumeration list of _twin_refln_include_status.
        2014-02-14  BMcM and NJA: minor editing for clean release version
 ;
-         3.1.0                    2024-11-28
+         3.1.0                    2024-11-29
 ;
        2014-06-20  Converted to DDLm (SRH/JRH)
        2024-11-21  Examples and history returned to main dictionary (JRH)
        2024-11-28  Redeclared _twin_individual.mass_fraction_refined as a
                    measurand (AV)
+       2024-11-29  Fix and improve text formatting in several definitions.
 ;

--- a/cif_twin.dic
+++ b/cif_twin.dic
@@ -388,7 +388,6 @@ save_twin_individual.twin_matrix
             (h' k' l') = | U21  U22  U23 | |k |
                          | U31  U32  U33 | |l |
 
-
      The reference twin must be assigned the identity matrix.
 ;
     _name.category_id             twin_individual


### PR DESCRIPTION
The text descriptions in a few matrix elements referred to the wrong matrix element. Layout of the twin matrix definition improved. These updates provided by Vic Young.